### PR TITLE
added package.json for npm dependencies for easier installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,26 +11,16 @@ NeoPixel RESTful node app provides a RESTful interface to the neopixel driver fo
 - NeoPixelI2cSlave firmware deployed on the mBed (https://developer.mbed.org/users/dwini/code/NeoPixelI2cSlave/)
 - Node installed on Raspberry Pi
 
-## Requirement node app
-- express
-- body-parser
-- i2c
-
 ### Version
 0.1 (alpha version)
 
 ### Installation
 
-TODO
-
 ```sh
-$ npm install express
-$ npm install body-parser
-$ npm install git+https://github.com/kelly/node-i2c.git
+$ npm install
 ```
 
 ### License
 TODO
 
 **Free Software, Hell Yeah!**
-

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "node_neopixel_rest",
+  "version": "0.1.0-alpha",
+  "description": "NeoPixel RESTful node app provides a RESTful interface to the neopixel driver for the Raspberry Pi.",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BioBoost/node_neopixel_rest.git"
+  },
+  "keywords": [
+    "neopixel",
+    "rest",
+    "api",
+    "raspberry",
+    "pi"
+  ],
+  "author": "Nico De Witte",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/BioBoost/node_neopixel_rest/issues"
+  },
+  "homepage": "https://github.com/BioBoost/node_neopixel_rest#readme",
+  "dependencies": {
+    "body-parser": "^1.14.1",
+    "express": "^4.13.3",
+    "node-i2c": "git+https://github.com/kelly/node-i2c.git"
+  }
+}


### PR DESCRIPTION
Just a little modification simplifying the installation. Dependencies are now bundled in the package.json used by nmp. Installation is now done with only one command (npm install).
